### PR TITLE
Fix python3 path resolution in vision setup and model download

### DIFF
--- a/Sources/GhostOS/Vision/VisionBridge.swift
+++ b/Sources/GhostOS/Vision/VisionBridge.swift
@@ -288,11 +288,32 @@ public enum VisionBridge {
             return venvPython
         }
 
-        // Homebrew Python
-        for path in ["/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
+        // Common absolute paths (Homebrew on Apple Silicon, Intel, system)
+        for path in ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"] {
             if FileManager.default.isExecutableFile(atPath: path) {
                 return path
             }
+        }
+
+        // Fall back to PATH lookup for pyenv, conda, nix, asdf, etc.
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", "which python3 2>/dev/null"]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            if process.terminationStatus == 0,
+               let output = String(data: data, encoding: .utf8)
+            {
+                let path = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !path.isEmpty { return path }
+            }
+        } catch {
+            // Silently fall through — no Python found
         }
 
         return nil

--- a/Sources/ghost/SetupWizard.swift
+++ b/Sources/ghost/SetupWizard.swift
@@ -340,7 +340,9 @@ struct SetupWizard {
         }
 
         // Step 6a: Ensure Python environment
-        if !hasPython && !hasLauncher {
+        // Set up the venv whenever mlx_vlm isn't already available — the launcher
+        // existing doesn't mean Python is ready for model download or sidecar use.
+        if !hasPython {
             print("  Setting up Python environment...")
             if !setupPythonVenv() {
                 printFail("Python venv setup failed")
@@ -352,9 +354,11 @@ struct SetupWizard {
                 return false
             }
             print("  Python environment: ready")
-        } else if hasPython {
-            print("  Python environment: ready")
         } else {
+            print("  Python environment: ready")
+        }
+
+        if hasLauncher {
             print("  Launcher: \(findGhostVisionBinary() ?? "found")")
         }
 
@@ -469,6 +473,21 @@ struct SetupWizard {
         VisionBridge.findModelPath()
     }
 
+    /// Resolve python3 to an absolute path by checking common locations then PATH.
+    /// Returns nil if python3 cannot be found.
+    private func resolveAbsolutePythonPath() -> String? {
+        let candidates = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return found
+        }
+        let which = runShell("which python3 2>/dev/null")
+        if which.exitCode == 0 {
+            let path = which.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !path.isEmpty { return path }
+        }
+        return nil
+    }
+
     /// Download ShowUI-2B model from HuggingFace
     private func downloadModel() -> Bool {
         let destDir = NSHomeDirectory() + "/.ghost-os/models/ShowUI-2B"
@@ -476,13 +495,17 @@ struct SetupWizard {
         // Create directory
         try? FileManager.default.createDirectory(atPath: destDir, withIntermediateDirectories: true)
 
-        // Use huggingface-cli if available, otherwise use Python
+        // Find Python — must be an absolute path since Process/URL(fileURLWithPath:)
+        // resolves bare names like "python3" relative to CWD, not via PATH.
         let venvPython = NSHomeDirectory() + "/.ghost-os/venv/bin/python3"
         let python: String
         if FileManager.default.isExecutableFile(atPath: venvPython) {
             python = venvPython
+        } else if let resolved = resolveAbsolutePythonPath() {
+            python = resolved
         } else {
-            python = "python3"
+            print("  ERROR: python3 not found. Install Python 3.9+ first.")
+            return false
         }
 
         // Download using huggingface_hub


### PR DESCRIPTION
## Summary

Fixes a bug where `ghost setup` fails to download the ShowUI-2B model on **every fresh Homebrew install** because Python is resolved relative to the current working directory instead of via PATH.

```
ERROR: Failed to run python3: Error Domain=NSCocoaErrorDomain Code=4
"The file "python3" doesn't exist."
UserInfo={NSFilePath=/Users/user/my-project/python3}
```

## Root Cause

Two interacting bugs in `SetupWizard.swift`:

**Bug 1 — Logic flaw skips venv creation (line 343):**
```swift
if !hasPython && !hasLauncher {  // ← hasLauncher is always true on Homebrew
    setupPythonVenv()            // ← never runs
}
```
On Homebrew installs, `ghost-vision` exists at `/opt/homebrew/bin/ghost-vision`, so `hasLauncher = true`. The venv is never created, but the launcher existing doesn't mean Python is available for the model download step.

**Bug 2 — Bare `"python3"` passed to `Process` (lines 485, 776):**
```swift
python = "python3"  // bare string, not absolute path
// ...
process.executableURL = URL(fileURLWithPath: executable)  // resolves as <CWD>/python3
```
Swift's `URL(fileURLWithPath:)` resolves bare names against CWD, not via PATH. So `"python3"` becomes `/Users/user/my-project/python3` — a file that doesn't exist.

## Who This Affects

Every user who:
- Installs from Homebrew (the recommended method)
- Runs `ghost setup` for the first time
- Doesn't already have `mlx_vlm` installed system-wide

This is the default path for all new users following the README.

## Changes

- **`setupVision()`** — Set up the Python venv whenever `mlx_vlm` is unavailable, regardless of whether the `ghost-vision` launcher binary exists. The launcher is for runtime; the venv is needed for setup.
- **`downloadModel()`** — Add `resolveAbsolutePythonPath()` helper that checks common absolute paths (`/opt/homebrew/bin/python3`, `/usr/local/bin/python3`, `/usr/bin/python3`) then falls back to `which python3`. This matches the exact pattern already used in `setupPythonVenv()`.
- **`VisionBridge.findPython()`** — Add `/usr/bin/python3` to the candidates list and a PATH-based fallback via `which python3` for users with Python installed via pyenv, conda, nix, asdf, etc.

## How This Fixes It For Every User

| Scenario | Before | After |
|---|---|---|
| Fresh Homebrew install, Python via Homebrew | Venv skipped (launcher exists), bare `"python3"` → CWD-relative → crash | Venv created, uses venv python → works |
| Fresh Homebrew install, Python via pyenv/conda | Same crash | `resolveAbsolutePythonPath()` finds it via `which` → works |
| Fresh Homebrew install, no Python at all | Same crash (misleading error) | Clear error: "python3 not found. Install Python 3.9+ first." |
| Existing install with venv already set up | Works (venv python found) | Works (no change to this path) |
| VisionBridge runtime after setup | Could return `nil` for non-standard Python installs | Falls back to `which python3` → finds it |

## Testing

- Reviewed all callers of `runShellLive()` and `VisionBridge.findPython()` for similar patterns — no other instances of bare executable names
- The new `resolveAbsolutePythonPath()` uses the exact same resolution logic as the existing `setupPythonVenv()` (lines 417-428), which has been working correctly
- Could not compile locally (requires Swift 6.2 toolchain / Xcode 26 beta) — changes are minimal and use only existing API patterns from the codebase

Fixes #1