### PR TITLE
Fix ghost_ground for new users (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ $ ghost doctor
   [ok] Recipes: 5 installed
   [ok] AX Tree: 12/12 apps readable
   [ok] ghost-vision: /opt/homebrew/bin/ghost-vision
-  [ok] ShowUI-2B model: ~/.ghost-os/models/ShowUI-2B (2.8 GB)
+  [ok] ShowUI-2B model: ~/.ghost-os/models/ShowUI-2B (3.0 GB)
   [ok] Vision Sidecar: not running (auto-starts when needed)
 
   All checks passed. Ghost OS is healthy.

--- a/Sources/GhostOS/Common/Types.swift
+++ b/Sources/GhostOS/Common/Types.swift
@@ -8,7 +8,7 @@ import Foundation
 // MARK: - Version
 
 public enum GhostOS {
-    public static let version = "2.1.0"
+    public static let version = "2.1.1"
     public static let name = "ghost-os"
 }
 

--- a/Sources/ghost/Doctor.swift
+++ b/Sources/ghost/Doctor.swift
@@ -30,6 +30,7 @@ struct Doctor {
         checkRecipes()
         checkAXTree()
         checkVisionBinary()
+        checkPythonVersion()
         checkShowUIModel()
         checkVisionSidecar()
 
@@ -251,6 +252,31 @@ struct Doctor {
         }
     }
 
+    // MARK: - Python Version
+
+    private mutating func checkPythonVersion() {
+        let venvPython = NSHomeDirectory() + "/.ghost-os/venv/bin/python3"
+        guard FileManager.default.isExecutableFile(atPath: venvPython) else {
+            return
+        }
+
+        let result = runShell("\(venvPython) -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\" 2>&1")
+        let version = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = version.split(separator: ".")
+        if parts.count >= 2,
+           let major = Int(parts[0]),
+           let minor = Int(parts[1]) {
+            if major < 3 || (major == 3 && minor < 10) {
+                print("  [!] Python version: \(version) (below minimum 3.10)")
+                print("    MLX requires Python 3.10+.")
+                print("    Fix: brew install python@3.12 && rm -rf ~/.ghost-os/venv && ghost setup")
+                warningCount += 1
+            } else {
+                print("  [ok] Python version: \(version)")
+            }
+        }
+    }
+
     // MARK: - ShowUI-2B Model
 
     private mutating func checkShowUIModel() {
@@ -265,7 +291,7 @@ struct Doctor {
                     print("  [ok] ShowUI-2B model: \(modelPath) (\(String(format: "%.1f", sizeGB)) GB)")
                 } else {
                     print("  [!] ShowUI-2B model: file seems too small (\(String(format: "%.2f", sizeGB)) GB)")
-                    print("    Expected: ~2.8 GB. May be incomplete download.")
+                    print("    Expected: ~3 GB. May be incomplete download.")
                     print("    Fix: rm -rf \(modelPath) && ghost setup")
                     warningCount += 1
                 }
@@ -290,13 +316,33 @@ struct Doctor {
                 warningCount += 1
             }
         } else {
-            print("  [!] ShowUI-2B model: not found")
-            print("    Checked:")
-            print("      /opt/homebrew/share/ghost-os/models/ShowUI-2B/")
-            print("      ~/.ghost-os/models/ShowUI-2B/")
-            print("      ~/.shadow/models/llm/ShowUI-2B-bf16-8bit/")
-            print("    Fix: ghost setup (downloads the model)")
-            warningCount += 1
+            // Check for PyTorch format model (common after broken setup)
+            let pytorchPaths = [
+                NSHomeDirectory() + "/.ghost-os/models/ShowUI-2B",
+                "/opt/homebrew/share/ghost-os/models/ShowUI-2B",
+            ]
+            var foundPytorch = false
+            for path in pytorchPaths {
+                let pytorchBin = (path as NSString).appendingPathComponent("pytorch_model.bin")
+                if FileManager.default.fileExists(atPath: pytorchBin) {
+                    print("  [FAIL] ShowUI-2B model: WRONG FORMAT")
+                    print("    Found pytorch_model.bin at \(path)")
+                    print("    Ghost OS requires MLX safetensors format, not PyTorch.")
+                    print("    Fix: rm -rf \(path) && ghost setup")
+                    issueCount += 1
+                    foundPytorch = true
+                    break
+                }
+            }
+            if !foundPytorch {
+                print("  [!] ShowUI-2B model: not found")
+                print("    Checked:")
+                print("      /opt/homebrew/share/ghost-os/models/ShowUI-2B/")
+                print("      ~/.ghost-os/models/ShowUI-2B/")
+                print("      ~/.shadow/models/llm/ShowUI-2B-bf16-8bit/")
+                print("    Fix: ghost setup (downloads the model)")
+                warningCount += 1
+            }
         }
     }
 

--- a/Sources/ghost/SetupWizard.swift
+++ b/Sources/ghost/SetupWizard.swift
@@ -331,7 +331,18 @@ struct SetupWizard {
         let hasLauncher = findGhostVisionBinary() != nil
         let hasPython = checkPythonWithMLX()
 
-        // Check for model
+        // Detect and remove broken PyTorch-format model (incompatible with MLX)
+        let ghostModelDir = NSHomeDirectory() + "/.ghost-os/models/ShowUI-2B"
+        let pytorchBin = (ghostModelDir as NSString).appendingPathComponent("pytorch_model.bin")
+        let safetensorsFile = (ghostModelDir as NSString).appendingPathComponent("model.safetensors")
+        if FileManager.default.fileExists(atPath: pytorchBin)
+            && !FileManager.default.fileExists(atPath: safetensorsFile) {
+            print("  Found ShowUI-2B in PyTorch format (not compatible with MLX).")
+            print("  Removing to re-download in correct format...")
+            try? FileManager.default.removeItem(atPath: ghostModelDir)
+        }
+
+        // Check for model after potential cleanup
         let modelPath = findModelPath()
         let hasModel = modelPath != nil
 
@@ -365,7 +376,7 @@ struct SetupWizard {
         // Step 6b: Download model if missing
         if !hasModel {
             print("")
-            print("  ShowUI-2B model not found. Download now? (~2.8 GB)")
+            print("  ShowUI-2B model not found. Download now? (~3 GB)")
             print("  This enables visual element grounding for web apps.")
             print("")
             print("  Download? (Y/n) ", terminator: "")
@@ -382,7 +393,7 @@ struct SetupWizard {
                 printFail("Model download failed")
                 print("  You can download manually:")
                 print("    pip3 install huggingface-hub")
-                print("    huggingface-cli download showlab/ShowUI-2B --local-dir ~/.ghost-os/models/ShowUI-2B")
+                print("    huggingface-cli download mlx-community/ShowUI-2B-bf16-8bit --local-dir ~/.ghost-os/models/ShowUI-2B")
                 print("")
                 return false
             }
@@ -417,18 +428,41 @@ struct SetupWizard {
     private func setupPythonVenv() -> Bool {
         let venvPath = NSHomeDirectory() + "/.ghost-os/venv"
 
-        // Find system Python
+        // Find system Python (prefer versioned paths to avoid Xcode's Python 3.9)
         let pythonPath: String
-        let candidates = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
+        let candidates = [
+            "/opt/homebrew/bin/python3",
+            "/opt/homebrew/bin/python3.13",
+            "/opt/homebrew/bin/python3.12",
+            "/opt/homebrew/bin/python3.11",
+            "/opt/homebrew/bin/python3.10",
+            "/usr/local/bin/python3",
+            "/usr/bin/python3",
+        ]
         if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
             pythonPath = found
         } else {
             let which = runShell("which python3 2>/dev/null")
             guard which.exitCode == 0, !which.output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                print("  ERROR: python3 not found. Install Python 3.9+ first.")
+                print("  ERROR: python3 not found. Install Python 3.10+ first.")
                 return false
             }
             pythonPath = which.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // MLX requires Python 3.10+
+        let versionResult = runShell("\(pythonPath) -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\" 2>&1")
+        let versionStr = versionResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let vParts = versionStr.split(separator: ".")
+        if vParts.count >= 2,
+           let major = Int(vParts[0]),
+           let minor = Int(vParts[1]) {
+            if major < 3 || (major == 3 && minor < 10) {
+                print("  ERROR: Python \(versionStr) detected. MLX requires Python 3.10+.")
+                print("  Install a newer Python: brew install python@3.12")
+                print("  Then run `ghost setup` again.")
+                return false
+            }
         }
 
         // Create venv (skip if already exists and has pip)
@@ -476,7 +510,15 @@ struct SetupWizard {
     /// Resolve python3 to an absolute path by checking common locations then PATH.
     /// Returns nil if python3 cannot be found.
     private func resolveAbsolutePythonPath() -> String? {
-        let candidates = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
+        let candidates = [
+            "/opt/homebrew/bin/python3",
+            "/opt/homebrew/bin/python3.13",
+            "/opt/homebrew/bin/python3.12",
+            "/opt/homebrew/bin/python3.11",
+            "/opt/homebrew/bin/python3.10",
+            "/usr/local/bin/python3",
+            "/usr/bin/python3",
+        ]
         if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
             return found
         }
@@ -504,7 +546,7 @@ struct SetupWizard {
         } else if let resolved = resolveAbsolutePythonPath() {
             python = resolved
         } else {
-            print("  ERROR: python3 not found. Install Python 3.9+ first.")
+            print("  ERROR: python3 not found. Install Python 3.10+ first.")
             return false
         }
 
@@ -518,23 +560,22 @@ struct SetupWizard {
         let downloadScript = """
         import sys
         dest = sys.argv[1]
-        try:
+        ALLOW = ["*.safetensors", "*.json", "merges.txt", "vocab.txt", "vocab.json", "tokenizer.model"]
+        def download(dest):
             from huggingface_hub import snapshot_download
-            path = snapshot_download(
-                "showlab/ShowUI-2B",
+            return snapshot_download(
+                "mlx-community/ShowUI-2B-bf16-8bit",
                 local_dir=dest,
                 local_dir_use_symlinks=False,
+                allow_patterns=ALLOW,
             )
-            print(f"Downloaded to: {path}")
+        try:
+            from huggingface_hub import snapshot_download
         except ImportError:
             import subprocess
             subprocess.check_call([sys.executable, "-m", "pip", "install", "--quiet", "huggingface-hub"])
-            from huggingface_hub import snapshot_download
-            path = snapshot_download(
-                "showlab/ShowUI-2B",
-                local_dir=dest,
-                local_dir_use_symlinks=False,
-            )
+        try:
+            path = download(dest)
             print(f"Downloaded to: {path}")
         except Exception as e:
             print(f"ERROR: {e}", file=sys.stderr)
@@ -555,22 +596,37 @@ struct SetupWizard {
 
         // Verify the download
         let safetensorsPath = (destDir as NSString).appendingPathComponent("model.safetensors")
-        if FileManager.default.fileExists(atPath: safetensorsPath) {
-            // Check file size (should be > 2GB)
-            if let attrs = try? FileManager.default.attributesOfItem(atPath: safetensorsPath),
-               let size = attrs[.size] as? UInt64
-            {
-                let sizeGB = Double(size) / 1_000_000_000
-                if sizeGB > 1.0 {
-                    print("")
-                    print("  Model downloaded successfully (\(String(format: "%.1f", sizeGB)) GB)")
-                    return true
-                }
+        let configPath = (destDir as NSString).appendingPathComponent("config.json")
+
+        guard FileManager.default.fileExists(atPath: safetensorsPath),
+              FileManager.default.fileExists(atPath: configPath) else {
+            let pytorchPath = (destDir as NSString).appendingPathComponent("pytorch_model.bin")
+            if FileManager.default.fileExists(atPath: pytorchPath) {
+                print("  ERROR: Model downloaded in PyTorch format (pytorch_model.bin).")
+                print("  Ghost OS requires MLX safetensors format.")
+                print("  Fix: rm -rf \(destDir) && ghost setup")
+            } else {
+                print("  ERROR: Download incomplete - model.safetensors not found.")
+            }
+            return false
+        }
+
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: safetensorsPath),
+           let size = attrs[.size] as? UInt64 {
+            let sizeGB = Double(size) / 1_000_000_000
+            if sizeGB > 1.0 {
+                print("")
+                print("  Model downloaded successfully (\(String(format: "%.1f", sizeGB)) GB)")
+                return true
+            } else {
+                print("  ERROR: model.safetensors too small (\(String(format: "%.2f", sizeGB)) GB). Download may be corrupt.")
+                print("  Fix: rm -rf \(destDir) && ghost setup")
+                return false
             }
         }
 
-        print("  WARNING: Model download may be incomplete. Check \(destDir)")
-        return true  // Still return true — might be usable
+        print("  ERROR: Could not verify model.safetensors file size.")
+        return false
     }
 
     /// Test the vision pipeline end-to-end

--- a/vision-sidecar/ghost-vision
+++ b/vision-sidecar/ghost-vision
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-VERSION="2.1.0"
+VERSION="2.1.1"
 
 # Find server.py in order of priority
 find_server_script() {

--- a/vision-sidecar/requirements.txt
+++ b/vision-sidecar/requirements.txt
@@ -6,6 +6,6 @@
 # Install: pip3 install -r requirements.txt
 
 mlx>=0.21.0
-mlx-vlm>=0.1.0
+mlx-vlm>=0.1.14
 transformers>=4.38.0
 Pillow>=10.0.0

--- a/vision-sidecar/server.py
+++ b/vision-sidecar/server.py
@@ -27,7 +27,7 @@ Usage:
   python3 server.py --version                 # Print version
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 import argparse
 import base64
@@ -78,11 +78,19 @@ def resolve_model_path(explicit_path=None):
 
     for path in candidates:
         if os.path.isdir(path):
-            # Verify it looks like a real model directory
             safetensors = os.path.join(path, "model.safetensors")
             config = os.path.join(path, "config.json")
             if os.path.isfile(safetensors) and os.path.isfile(config):
                 return path
+            pytorch_bin = os.path.join(path, "pytorch_model.bin")
+            if os.path.isfile(pytorch_bin):
+                log(f"WARNING: Model at {path} is in PyTorch format (pytorch_model.bin). "
+                    f"Ghost OS requires MLX safetensors format. "
+                    f"Fix: rm -rf {path} && ghost setup")
+            elif os.path.isfile(config):
+                log(f"WARNING: Model at {path} has config.json but no model.safetensors. "
+                    f"Download may be incomplete. "
+                    f"Fix: rm -rf {path} && ghost setup")
 
     # Return first candidate for error message
     return candidates[0] if candidates else str(Path.home() / ".ghost-os/models/ShowUI-2B")
@@ -98,14 +106,14 @@ _vlm_load_error = None
 
 
 def _load_vlm():
-    """Load ShowUI-2B model. Called once, cached forever."""
+    """Load ShowUI-2B model. Retries on each call if previously failed."""
     global _vlm_model, _vlm_processor, _vlm_tokenizer, _vlm_load_error
 
     with _vlm_lock:
         if _vlm_model is not None:
             return True
-        if _vlm_load_error is not None:
-            return False
+
+        _vlm_load_error = None
 
         try:
             log(f"Loading ShowUI-2B from {MODEL_PATH}...")


### PR DESCRIPTION
## What

`ghost setup` was downloading `showlab/ShowUI-2B` which ships as `pytorch_model.bin`. But `mlx_vlm.load()` requires `model.safetensors`. Every new user got a broken vision sidecar after a clean install.

Now downloads `mlx-community/ShowUI-2B-bf16-8bit` (pre-converted MLX format, 3 GB). Works out of the box with `mlx_vlm`.

## Changes

**SetupWizard.swift**
- Download from `mlx-community/ShowUI-2B-bf16-8bit` instead of `showlab/ShowUI-2B`
- Use `allow_patterns` to download only inference-essential files (safetensors, config, tokenizer)
- Validate `model.safetensors` + `config.json` exist after download, fail hard if missing
- Detect and auto-remove broken PyTorch model from previous installs
- Add Python 3.10+ version check (MLX requirement)
- Add versioned Python candidates (`python3.13` through `python3.10`) to avoid Xcode's bundled 3.9

**server.py**
- Log clear diagnostics when model directory exists but has wrong format
- Remove permanent error caching so model load retries on subsequent requests

**Doctor.swift**
- Detect `pytorch_model.bin` and show `[FAIL] ShowUI-2B model: WRONG FORMAT` with fix instructions
- Add Python version check for the venv
- Update expected model size to 3 GB

**Other**
- Version bump to 2.1.1 (Types.swift, server.py, ghost-vision)
- Tighten `mlx-vlm>=0.1.14` in requirements.txt
- Update README model size reference

## Test plan

- [x] `swift build` passes
- [x] `ghost doctor` all green with valid model
- [x] `ghost setup` detects and removes broken PyTorch model
- [x] `ghost setup` finds valid model at fallback path after cleanup
- [x] Zero references to `showlab/ShowUI-2B` in codebase
- [x] Version 2.1.1 consistent across all 3 files
- [ ] Fresh download from HuggingFace (requires ~3 GB download)
- [ ] E2E: `ghost_ground` call returns valid coordinates

Closes #3