### PR TITLE
Add self-learning recipes (ghost_learn) for v2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ DerivedData/
 .DS_Store
 local/
 
+# Claude Code plugin (local development)
+.claude-plugin/
+agents/
+skills/
+
 # Release artifacts
 ghost-os-*.tar.gz
 

--- a/GHOST-MCP.md
+++ b/GHOST-MCP.md
@@ -5,8 +5,9 @@ through the accessibility tree AND visual perception. Every button, text field,
 link, and label is available -- either through the AX tree (native apps) or
 vision-based grounding (web apps where Chrome exposes everything as AXGroup).
 
-You have 26 tools: perceive the screen, click, type, hover, drag, long-press,
-scroll, press keys, manage windows, wait for conditions, and run saved recipes.
+You have 29 tools: perceive the screen, click, type, hover, drag, long-press,
+scroll, press keys, manage windows, wait for conditions, run saved recipes,
+and learn new workflows by watching the user.
 
 ## Rule 1: Always Check Recipes First
 
@@ -221,6 +222,39 @@ Common wait conditions:
 - `elementExists` -- wait for an element to appear
 - `elementGone` -- wait for a loading indicator to disappear
 
+## Rule 13: Self-Learning Mode
+
+Ghost OS can learn workflows by watching the user perform them.
+
+### How to use learning mode
+1. User says they want to teach a workflow
+2. Call `ghost_learn_start` with a task_description
+3. Tell the user to perform the task
+4. User says they are done
+5. Call `ghost_learn_stop` to get the recorded actions
+6. Analyze the actions: identify parameters (email addresses, names, URLs that should be substitutable)
+7. Synthesize a recipe JSON from the actions
+8. Call `ghost_recipe_save` with the recipe JSON
+
+### Synthesizing recipes from recordings
+When you receive the action array from ghost_learn_stop:
+- Each `click` with an `element` context becomes a recipe step with a target Locator
+- Use `dom_id` as the primary criterion if available (most stable for web apps)
+- Use `role` + `computedNameContains` as secondary criteria
+- Each `typeText` where the text looks like user-specific data (email, name, URL) becomes a `{{parameter}}`
+- Each `keyPress` for Tab/Return becomes a `press` step
+- Each `hotkey` becomes a `hotkey` step
+- Each `appSwitch` becomes a `focus` step
+- Infer `wait_after` conditions from timing gaps (>2s between actions suggests a page load)
+- The recipe must use schema_version 2 and be compatible with ghost_run
+
+### Requirements
+- Input Monitoring permission required (separate from Accessibility)
+- Only records between ghost_learn_start and ghost_learn_stop (no background monitoring)
+- Password fields are automatically redacted
+- Recordings are ephemeral (in memory only, never written to disk)
+- Do not call ghost_run while ghost_learn is active (synthetic events would be re-recorded)
+
 ## Tool Reference
 
 | Tool | Purpose | Needs Focus? |
@@ -251,3 +285,6 @@ Common wait conditions:
 | ghost_recipe_delete | Delete recipe | No |
 | ghost_parse_screen | Detect ALL UI elements via vision | No |
 | ghost_ground | Find element coordinates via VLM | No |
+| ghost_learn_start | Start observing user actions for learning | No |
+| ghost_learn_stop | Stop observing and return recorded actions | No |
+| ghost_learn_status | Check learning mode status | No |

--- a/README.md
+++ b/README.md
@@ -18,18 +18,38 @@ Your AI agent can write code, run tests, search files. But it can't click a butt
 
 Ghost OS changes that. One install, and any AI agent can see and operate every app on your Mac.
 
-### What's New &nbsp; <img src="https://img.shields.io/badge/v2.1.2-March%2010%2C%202026-brightgreen.svg" alt="v2.1.2">
+### What's New &nbsp; <img src="https://img.shields.io/badge/v2.2.0-March%202026-brightgreen.svg" alt="v2.2.0">
 
-4 new tools. 26 total. Ghost OS can now annotate, hover, long-press, and drag.
+**Self-learning recipes.** Show Ghost OS how to do something once, and it remembers forever.
 
-- **`ghost_annotate`** takes a screenshot with numbered labels on every interactive element. The agent sees `[1] Button "Send"`, `[2] Link "Inbox"` with exact click coordinates. No vision model needed.
-- **`ghost_hover`** moves the cursor to trigger tooltips, CSS :hover effects, and dropdown menus without clicking.
-- **`ghost_long_press`** presses and holds for context menus, Force Touch previews, and drag initiation.
-- **`ghost_drag`** drags files between folders, adjusts sliders, reorders lists, selects text, resizes panes.
+- **`ghost_learn_start`** -- Begin watching the user perform a task
+- **`ghost_learn_stop`** -- Stop and return the enriched action sequence
+- **`ghost_learn_status`** -- Check recording progress
 
-![Ghost OS New Tools Demo](demo-new-tools.gif)
+The user performs the task manually (clicking, typing, switching apps). Ghost OS observes every action through a CGEvent tap enriched with accessibility tree context. Claude synthesizes the raw observation into a parameterized, replayable recipe.
 
-Also in v2.1.2: pinned vision sidecar dependencies for reliable ghost_ground, fixed vision model download, and Chinese/CJK input support (thanks [@junshi5218](https://github.com/junshi5218)).
+No screenshots needed. No vision model. Just the accessibility tree and your keyboard/mouse.
+
+```
+User:    "Watch me send an email."
+Agent:   ghost_learn_start task_description:"send email in Gmail"
+         ...user performs the task...
+Agent:   ghost_learn_stop
+         -> 8 actions with full AX context
+         -> Synthesizes recipe with 3 parameters: recipient, subject, body
+         -> ghost_recipe_save
+User:    "Send an email to bob about the Q4 report"
+Agent:   ghost_run recipe:"gmail-send-learned" params:{...}
+```
+
+Requires Input Monitoring permission (System Settings > Privacy & Security > Input Monitoring). Run `ghost setup` to configure.
+
+<details>
+<summary>Previous: v2.1.2</summary>
+
+4 new tools. ghost_annotate, ghost_hover, ghost_long_press, ghost_drag. Pinned vision sidecar dependencies, fixed vision model download, Chinese/CJK input support (thanks [@junshi5218](https://github.com/junshi5218)).
+
+</details>
 
 Thank you to the 300+ people who have starred this project. You are why we keep building. If you want to contribute directly, we would love that. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -88,7 +108,7 @@ That's it. `ghost setup` handles permissions, MCP configuration, recipe installa
 Homebrew has a known issue on macOS developer betas where it demands an Xcode version that doesn't exist yet. If `brew install` fails, install directly:
 
 ```bash
-curl -sL https://github.com/ghostwright/ghost-os/releases/latest/download/ghost-os-2.1.2-macos-arm64.tar.gz | tar xz
+curl -sL https://github.com/ghostwright/ghost-os/releases/latest/download/ghost-os-2.2.0-macos-arm64.tar.gz | tar xz
 sudo cp ghost /opt/homebrew/bin/
 sudo cp ghost-vision /opt/homebrew/bin/
 sudo mkdir -p /opt/homebrew/share/ghost-os
@@ -102,7 +122,7 @@ ghost setup
 
 ## How It Works
 
-Ghost OS connects to your AI agent through [MCP](https://modelcontextprotocol.io) and gives it 26 tools to see and operate your Mac. It reads the macOS accessibility tree for structured data about every app. For web apps where the AX tree falls short (Gmail, Slack), a local vision model (ShowUI-2B) finds elements visually. Click, type, hover, drag, scroll, press keys, manage windows. Any app, not just browsers.
+Ghost OS connects to your AI agent through [MCP](https://modelcontextprotocol.io) and gives it 29 tools to see and operate your Mac. It reads the macOS accessibility tree for structured data about every app. For web apps where the AX tree falls short (Gmail, Slack), a local vision model (ShowUI-2B) finds elements visually. Click, type, hover, drag, scroll, press keys, manage windows. Any app, not just browsers.
 
 ```
 You:     "Download the latest paper on chain-of-thought prompting from arXiv"
@@ -130,7 +150,7 @@ ghost_run recipe:"gmail-send" params:{"recipient":"hello@example.com","subject":
 - Chain recipes together. The agent knows when to call what.
 - Write once with Claude or GPT-4. Run forever with Haiku.
 
-## 26 Tools
+## 29 Tools
 
 | | Tool | What it does |
 |:---:|------|-------------|
@@ -160,6 +180,9 @@ ghost_run recipe:"gmail-send" params:{"recipient":"hello@example.com","subject":
 | 📦 | `ghost_recipe_show` | View the full steps and configuration of a recipe |
 | 📦 | `ghost_recipe_save` | Install a new recipe from JSON |
 | 📦 | `ghost_recipe_delete` | Remove an installed recipe |
+| 🎓 | `ghost_learn_start` | Start observing the user's actions for workflow learning |
+| 🎓 | `ghost_learn_stop` | Stop observing and return the enriched action sequence |
+| 🎓 | `ghost_learn_status` | Check if learning mode is active and recording stats |
 
 ## Diagnostics
 
@@ -168,6 +191,7 @@ $ ghost doctor
 
   [ok] Accessibility: granted
   [ok] Screen Recording: granted
+  [ok] Input Monitoring: granted (for learning mode)
   [ok] Processes: 1 ghost MCP process
   [ok] MCP Config: ghost-os configured
   [ok] Recipes: 5 installed

--- a/Sources/GhostOS/Common/Types.swift
+++ b/Sources/GhostOS/Common/Types.swift
@@ -8,7 +8,7 @@ import Foundation
 // MARK: - Version
 
 public enum GhostOS {
-    public static let version = "2.1.2"
+    public static let version = "2.2.0"
     public static let name = "ghost-os"
 }
 

--- a/Sources/GhostOS/Learning/AppSwitchDetector.swift
+++ b/Sources/GhostOS/Learning/AppSwitchDetector.swift
@@ -1,0 +1,55 @@
+// AppSwitchDetector.swift - Detects app switches during learning
+//
+// Polls NSWorkspace.shared.frontmostApplication on each event.
+// When the frontmost app differs from the last recorded app,
+// injects an appSwitch action into the recording.
+// This detects Cmd+Tab, three-finger swipe, Dock clicks, etc.
+// CGEvent tap alone cannot capture these -- polling is required.
+
+import AppKit
+import Foundation
+
+nonisolated enum AppSwitchDetector {
+
+    /// Check if the frontmost app changed. If so, record an appSwitch action.
+    /// Returns true if a switch was detected.
+    @discardableResult
+    static func checkAndRecord(
+        recorder: LearningRecorder,
+        lastRecordedApp: inout String
+    ) -> Bool {
+        guard let frontApp = NSWorkspace.shared.frontmostApplication,
+              let name = frontApp.localizedName else {
+            return false
+        }
+
+        // Skip the first call (initial app detection, not a user-initiated switch)
+        guard name != lastRecordedApp, !lastRecordedApp.isEmpty else {
+            if lastRecordedApp.isEmpty {
+                lastRecordedApp = name
+            }
+            return false
+        }
+
+        let bundleId = frontApp.bundleIdentifier ?? ""
+        let previousApp = lastRecordedApp
+        lastRecordedApp = name
+
+        // Flush pending coalesced events from the previous app
+        recorder.flushPendingKeystrokesOnLearningThread()
+        recorder.flushPendingScrollOnLearningThread()
+
+        recorder.appendAction(ObservedAction(
+            timestamp: mach_absolute_time(),
+            action: .appSwitch(toApp: name, toBundleId: bundleId),
+            appName: previousApp,
+            appBundleId: "",
+            windowTitle: nil,
+            url: nil,
+            elementContext: nil
+        ))
+
+        learningLog("DEBUG", "Learning: app switch detected \(previousApp) -> \(name)")
+        return true
+    }
+}

--- a/Sources/GhostOS/Learning/EventHandlers.swift
+++ b/Sources/GhostOS/Learning/EventHandlers.swift
@@ -1,0 +1,256 @@
+// EventHandlers.swift - Per-event-type handling with AX enrichment
+//
+// Called from LearningRecorder.handleEvent() on the learning thread.
+// All AX calls use the raw C API (AXUIElementCopyElementAtPosition,
+// AXUIElementCopyAttributeValue) to avoid @MainActor isolation.
+
+import ApplicationServices
+import AppKit
+import Foundation
+
+/// Handles individual CGEvent types during learning.
+/// nonisolated because all methods run on the learning thread.
+nonisolated enum EventHandlers {
+
+    // MARK: - Key Down
+
+    static func handleKeyDown(_ event: CGEvent, recorder: LearningRecorder) {
+        // Never record password keystrokes
+        if isSecureFieldFocused() {
+            recorder.flushPendingKeystrokesOnLearningThread()
+            let (app, bid) = currentAppInfo()
+            recorder.appendAction(ObservedAction(
+                timestamp: mach_absolute_time(), action: .secureField,
+                appName: app, appBundleId: bid,
+                windowTitle: nil, url: nil, elementContext: nil
+            ))
+            return
+        }
+
+        let keyCode = Int(event.getIntegerValueField(.keyboardEventKeycode))
+        let flags = event.flags
+        var mods: [String] = []
+        if flags.contains(.maskCommand) { mods.append("cmd") }
+        if flags.contains(.maskShift) { mods.append("shift") }
+        if flags.contains(.maskAlternate) { mods.append("option") }
+        if flags.contains(.maskControl) { mods.append("control") }
+
+        let chars = keyChars(from: event)
+
+        if let chars, mods.isEmpty {
+            // Coalesce character keys into pending buffer
+            recorder.withLock { session in
+                guard session != nil else { return }
+                if recorder.pendingKeystrokes.isEmpty {
+                    recorder.pendingKeystrokeElement = focusedFieldContext()
+                    recorder.pendingKeystrokeTimestamp = mach_absolute_time()
+                    let (app, bid) = currentAppInfo()
+                    recorder.pendingKeystrokeApp = app
+                    recorder.pendingKeystrokeBundleId = bid
+                    recorder.pendingKeystrokeWindow = currentWindowTitle()
+                    recorder.pendingKeystrokeUrl = currentURL()
+                }
+                recorder.pendingKeystrokes.append(chars)
+            }
+            recorder.scheduleKeystrokeFlushTimer()
+        } else {
+            // Non-character key or modifier combo: flush pending, record discrete action
+            recorder.flushPendingKeystrokesOnLearningThread()
+            let keyName = keyNameForCode(keyCode)
+            let (app, bid) = currentAppInfo()
+            let actionType: ObservedActionType = !mods.isEmpty
+                ? .hotkey(modifiers: mods, keyName: keyName)
+                : .keyPress(keyCode: keyCode, keyName: keyName, modifiers: [])
+            recorder.appendAction(ObservedAction(
+                timestamp: mach_absolute_time(), action: actionType,
+                appName: app, appBundleId: bid,
+                windowTitle: currentWindowTitle(), url: nil, elementContext: nil
+            ))
+        }
+    }
+
+    // MARK: - Mouse Down
+
+    static func handleMouseDown(_ type: CGEventType, _ event: CGEvent, recorder: LearningRecorder) {
+        recorder.flushPendingKeystrokesOnLearningThread()
+        recorder.flushPendingScrollOnLearningThread()
+
+        let loc = event.location
+        let button: String = (type == .leftMouseDown) ? "left" : "right"
+        let clicks = Int(event.getIntegerValueField(.mouseEventClickState))
+        let (app, bid) = currentAppInfo()
+
+        recorder.appendAction(ObservedAction(
+            timestamp: mach_absolute_time(),
+            action: .click(x: Double(loc.x), y: Double(loc.y), button: button, count: clicks),
+            appName: app, appBundleId: bid,
+            windowTitle: currentWindowTitle(), url: currentURL(),
+            elementContext: enrichClick(at: loc)
+        ))
+    }
+
+    // MARK: - Scroll
+
+    static func handleScroll(_ event: CGEvent, recorder: LearningRecorder) {
+        let dy = Int(event.getIntegerValueField(.scrollWheelEventDeltaAxis1))
+        let dx = Int(event.getIntegerValueField(.scrollWheelEventDeltaAxis2))
+        guard dx != 0 || dy != 0 else { return }
+
+        recorder.flushPendingKeystrokesOnLearningThread()
+        let loc = event.location
+        let (app, bid) = currentAppInfo()
+
+        recorder.withLock { session in
+            guard session != nil else { return }
+            if recorder.pendingScrollDeltaX == 0 && recorder.pendingScrollDeltaY == 0 {
+                recorder.pendingScrollTimestamp = mach_absolute_time()
+                recorder.pendingScrollApp = app
+                recorder.pendingScrollBundleId = bid
+                recorder.pendingScrollX = Double(loc.x)
+                recorder.pendingScrollY = Double(loc.y)
+            }
+            recorder.pendingScrollDeltaX += dx
+            recorder.pendingScrollDeltaY += dy
+        }
+        recorder.scheduleScrollFlushTimer()
+    }
+
+    // MARK: - AX Enrichment
+
+    /// Hit-test at click point to identify the element.
+    private static func enrichClick(at location: CGPoint) -> ElementContext? {
+        let sys = AXUIElementCreateSystemWide()
+        var element: AXUIElement?
+        let err = AXUIElementCopyElementAtPosition(sys, Float(location.x), Float(location.y), &element)
+        guard err == .success, let el = element else { return nil }
+
+        let role = axAttr(el, kAXRoleAttribute) as? String
+        let title = (axAttr(el, kAXTitleAttribute) as? String).map { String($0.prefix(200)) }
+        let ident = (axAttr(el, kAXIdentifierAttribute) as? String).map { String($0.prefix(200)) }
+        let domId = axAttr(el, "AXDOMIdentifier") as? String
+        let domClasses: String? = {
+            guard let v = axAttr(el, "AXDOMClassList") else { return nil }
+            if let s = v as? String { return s }
+            if let a = v as? [String] { return a.joined(separator: " ") }
+            return nil
+        }()
+        let desc = (axAttr(el, kAXDescriptionAttribute) as? String).map { String($0.prefix(200)) }
+        var parentRole: String?
+        if let pv = axAttr(el, kAXParentAttribute) {
+            // CF types: AXUIElement downcast always succeeds (CFTypeRef bridging)
+            parentRole = axAttr(pv as! AXUIElement, kAXRoleAttribute) as? String
+        }
+        return ElementContext(role: role, title: title, identifier: ident,
+            domId: domId, domClasses: domClasses,
+            computedName: title ?? desc, parentRole: parentRole)
+    }
+
+    /// Get AX context for the currently focused element (typing context).
+    private static func focusedFieldContext() -> ElementContext? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        guard let fv = axAttr(appEl, kAXFocusedUIElementAttribute) else { return nil }
+        let el = fv as! AXUIElement  // CF type: downcast always succeeds
+        let role = axAttr(el, kAXRoleAttribute) as? String
+        let title = (axAttr(el, kAXTitleAttribute) as? String).map { String($0.prefix(200)) }
+        let desc = (axAttr(el, kAXDescriptionAttribute) as? String).map { String($0.prefix(200)) }
+        let domId = axAttr(el, "AXDOMIdentifier") as? String
+        let ident = (axAttr(el, kAXIdentifierAttribute) as? String).map { String($0.prefix(200)) }
+        return ElementContext(role: role, title: title, identifier: ident,
+            domId: domId, domClasses: nil, computedName: title ?? desc, parentRole: nil)
+    }
+
+    // MARK: - Secure Field Detection
+
+    /// Three-tier check: (1) AXSecureTextField role, (2) subrole,
+    /// (3) name heuristics for Chrome which renders password fields as AXTextField.
+    private static func isSecureFieldFocused() -> Bool {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return false }
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        guard let fv = axAttr(appEl, kAXFocusedUIElementAttribute) else { return false }
+        let focused = fv as! AXUIElement  // CF type: downcast always succeeds
+
+        let role = axAttr(focused, kAXRoleAttribute) as? String
+        if role == "AXSecureTextField" { return true }
+        let subrole = axAttr(focused, kAXSubroleAttribute) as? String
+        if subrole == "AXSecureTextField" { return true }
+
+        let title = (axAttr(focused, kAXTitleAttribute) as? String ?? "").lowercased()
+        let desc = (axAttr(focused, kAXDescriptionAttribute) as? String ?? "").lowercased()
+        let id = (axAttr(focused, kAXIdentifierAttribute) as? String ?? "").lowercased()
+        return LearningConstants.sensitiveFieldPatterns.contains { p in
+            title.contains(p) || desc.contains(p) || id.contains(p)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func axAttr(_ el: AXUIElement, _ attr: String) -> AnyObject? {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(el, attr as CFString, &value) == .success else { return nil }
+        return value
+    }
+
+    static func currentAppInfo() -> (name: String, bundleId: String) {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return ("Unknown", "") }
+        return (app.localizedName ?? "Unknown", app.bundleIdentifier ?? "")
+    }
+
+    static func currentWindowTitle() -> String? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        guard let wv = axAttr(appEl, kAXFocusedWindowAttribute) else { return nil }
+        let win = wv as! AXUIElement  // CF type: downcast always succeeds
+        return (axAttr(win, kAXTitleAttribute) as? String).map { String($0.prefix(200)) }
+    }
+
+    static func currentURL() -> String? {
+        guard let app = NSWorkspace.shared.frontmostApplication,
+              let bid = app.bundleIdentifier else { return nil }
+        let browsers: Set<String> = [
+            "com.google.Chrome", "com.apple.Safari", "company.thebrowser.Browser",
+            "org.mozilla.firefox", "com.brave.Browser", "com.microsoft.edgemac",
+        ]
+        guard browsers.contains(bid) else { return nil }
+        let appEl = AXUIElementCreateApplication(app.processIdentifier)
+        guard let wv = axAttr(appEl, kAXFocusedWindowAttribute) else { return nil }
+        let win = wv as! AXUIElement  // CF type: downcast always succeeds
+        return findURLField(in: win, depth: 0)
+    }
+
+    private static func findURLField(in el: AXUIElement, depth: Int) -> String? {
+        guard depth < 6 else { return nil }
+        let role = axAttr(el, kAXRoleAttribute) as? String
+        if role == "AXTextField" || role == "AXComboBox" {
+            let desc = (axAttr(el, kAXDescriptionAttribute) as? String ?? "").lowercased()
+            if desc.contains("address") || desc.contains("url") || desc.contains("search or enter") {
+                return axAttr(el, kAXValueAttribute) as? String
+            }
+        }
+        guard let children = axAttr(el, kAXChildrenAttribute) as? [AXUIElement] else { return nil }
+        for child in children {
+            if let url = findURLField(in: child, depth: depth + 1) { return url }
+        }
+        return nil
+    }
+
+    private static func keyChars(from event: CGEvent) -> String? {
+        guard let nsEvent = NSEvent(cgEvent: event) else { return nil }
+        guard let chars = nsEvent.characters, !chars.isEmpty else { return nil }
+        if chars.unicodeScalars.allSatisfy({ $0.value < 32 || $0.value == 127 }) { return nil }
+        return chars
+    }
+
+    static func keyNameForCode(_ code: Int) -> String {
+        switch code {
+        case 36: "return"; case 48: "tab"; case 49: "space"; case 51: "delete"
+        case 53: "escape"; case 123: "left"; case 124: "right"; case 125: "down"
+        case 126: "up"; case 115: "home"; case 119: "end"; case 116: "pageup"
+        case 121: "pagedown"; case 117: "forwarddelete"
+        case 122: "f1"; case 120: "f2"; case 99: "f3"; case 118: "f4"
+        case 96: "f5"; case 97: "f6"; case 98: "f7"; case 100: "f8"
+        case 101: "f9"; case 109: "f10"; case 103: "f11"; case 111: "f12"
+        default: "key\(code)"
+        }
+    }
+}

--- a/Sources/GhostOS/Learning/LearningDispatch.swift
+++ b/Sources/GhostOS/Learning/LearningDispatch.swift
@@ -1,0 +1,129 @@
+// LearningDispatch.swift - MCP tool handlers for learning mode
+//
+// Bridges MCPDispatch to LearningRecorder.
+// Handles parameter extraction, error formatting, and JSON serialization.
+
+import Foundation
+
+/// MCP tool handlers for ghost_learn_start, ghost_learn_stop, ghost_learn_status.
+public enum LearningDispatch {
+
+    // MARK: - ghost_learn_start
+
+    public static func learnStart(args: [String: Any]) -> ToolResult {
+        let taskDescription = args["task_description"] as? String
+        let recorder = LearningRecorder.shared
+
+        if let error = recorder.start(taskDescription: taskDescription) {
+            return ToolResult(
+                success: false,
+                error: error.localizedDescription,
+                suggestion: error.suggestion
+            )
+        }
+
+        return ToolResult(
+            success: true,
+            data: [
+                "status": "recording",
+                "message": "Recording started. The user can now perform the task. Call ghost_learn_stop when done.",
+            ]
+        )
+    }
+
+    // MARK: - ghost_learn_stop
+
+    public static func learnStop(args: [String: Any]) -> ToolResult {
+        let recorder = LearningRecorder.shared
+
+        switch recorder.stop() {
+        case .failure(let error):
+            return ToolResult(
+                success: false,
+                error: error.localizedDescription,
+                suggestion: error.suggestion
+            )
+        case .success(let (session, actions)):
+            let duration = Date().timeIntervalSince(session.startTime)
+            let serializedActions = actions.map { serializeAction($0) }
+
+            return ToolResult(
+                success: true,
+                data: [
+                    "task_description": session.taskDescription ?? "",
+                    "duration_seconds": Int(duration),
+                    "action_count": actions.count,
+                    "apps": Array(session.apps),
+                    "urls": session.urls,
+                    "actions": serializedActions,
+                ]
+            )
+        }
+    }
+
+    // MARK: - ghost_learn_status
+
+    public static func learnStatus(args: [String: Any]) -> ToolResult {
+        let (recording, count, duration, app) = LearningRecorder.shared.status()
+        var data: [String: Any] = [
+            "recording": recording,
+            "action_count": count,
+            "duration_seconds": Int(duration),
+        ]
+        if let app { data["current_app"] = app }
+        return ToolResult(success: true, data: data)
+    }
+
+    // MARK: - Serialization
+
+    private static func serializeAction(_ action: ObservedAction) -> [String: Any] {
+        var dict: [String: Any] = [
+            "timestamp": action.timestamp,
+            "app": action.appName,
+            "bundle_id": action.appBundleId,
+        ]
+        dict["window"] = action.windowTitle ?? NSNull()
+        dict["url"] = action.url ?? NSNull()
+        dict["element"] = action.elementContext.map { serializeElement($0) } ?? NSNull()
+
+        switch action.action {
+        case .click(let x, let y, let button, let count):
+            dict["action_type"] = "click"
+            dict["x"] = x; dict["y"] = y
+            dict["button"] = button; dict["count"] = count
+        case .typeText(let text):
+            dict["action_type"] = "typeText"
+            dict["text"] = text
+        case .keyPress(let keyCode, let keyName, let modifiers):
+            dict["action_type"] = "keyPress"
+            dict["key_code"] = keyCode; dict["key_name"] = keyName
+            dict["modifiers"] = modifiers
+        case .hotkey(let modifiers, let keyName):
+            dict["action_type"] = "hotkey"
+            dict["modifiers"] = modifiers; dict["key_name"] = keyName
+        case .appSwitch(let toApp, let toBundleId):
+            dict["action_type"] = "appSwitch"
+            dict["to_app"] = toApp; dict["to_bundle_id"] = toBundleId
+        case .scroll(let dx, let dy, let x, let y):
+            dict["action_type"] = "scroll"
+            dict["delta_x"] = dx; dict["delta_y"] = dy
+            dict["x"] = x; dict["y"] = y
+        case .secureField:
+            dict["action_type"] = "secureField"
+        }
+
+        return dict
+    }
+
+    private static func serializeElement(_ e: ElementContext) -> [String: Any] {
+        var dict: [String: Any] = [:]
+        if let v = e.role { dict["role"] = v }
+        if let v = e.title { dict["title"] = v }
+        if let v = e.identifier { dict["identifier"] = v }
+        if let v = e.domId { dict["dom_id"] = v }
+        if let v = e.domClasses { dict["dom_classes"] = v }
+        if let v = e.computedName { dict["computed_name"] = v }
+        if let v = e.parentRole { dict["parent_role"] = v }
+        return dict
+    }
+}

--- a/Sources/GhostOS/Learning/LearningRecorder.swift
+++ b/Sources/GhostOS/Learning/LearningRecorder.swift
@@ -1,0 +1,305 @@
+// LearningRecorder.swift - CGEvent tap lifecycle and action recording
+//
+// Owns the background thread, CGEvent tap, and thread-safe action buffer.
+// All methods are nonisolated because this class manages its own thread safety
+// via os_unfair_lock. Uses learningLog() instead of Log because Log inherits
+// MainActor from the package default and cannot be called from background threads.
+
+import ApplicationServices
+import AppKit
+import Foundation
+
+/// Records user input events during learning mode.
+/// Thread-safe via os_unfair_lock. Accessed from both the main thread
+/// (MCP dispatch) and the learning thread (CGEvent callback).
+nonisolated public final class LearningRecorder: @unchecked Sendable {
+
+    public static let shared = LearningRecorder()
+
+    // MARK: - Lock-protected state
+
+    private var lock = os_unfair_lock()
+    private var session: LearningSession?
+    private var eventTap: CFMachPort?
+    private var learningRunLoop: CFRunLoop?
+    private var learningThread: Thread?
+
+    // Keystroke coalescing -- only access within withLock or flushPending* (caller holds lock)
+    internal var pendingKeystrokes: String = ""
+    internal var pendingKeystrokeTimestamp: UInt64 = 0
+    internal var pendingKeystrokeApp: String = ""
+    internal var pendingKeystrokeBundleId: String = ""
+    internal var pendingKeystrokeWindow: String?
+    internal var pendingKeystrokeUrl: String?
+    internal var pendingKeystrokeElement: ElementContext?
+    private var keystrokeFlushTimer: CFRunLoopTimer?
+
+    // Max duration safety timer
+    private var maxDurationTimer: CFRunLoopTimer?
+
+    // Scroll coalescing -- only access within withLock or flushPending* (caller holds lock)
+    internal var pendingScrollDeltaX: Int = 0
+    internal var pendingScrollDeltaY: Int = 0
+    internal var pendingScrollX: Double = 0
+    internal var pendingScrollY: Double = 0
+    internal var pendingScrollTimestamp: UInt64 = 0
+    internal var pendingScrollApp: String = ""
+    internal var pendingScrollBundleId: String = ""
+    private var scrollFlushTimer: CFRunLoopTimer?
+
+    private var lastRecordedAppName: String = ""
+
+    private init() {}
+
+    // MARK: - Public API
+
+    public var isRecording: Bool {
+        os_unfair_lock_lock(&lock); defer { os_unfair_lock_unlock(&lock) }
+        return session != nil
+    }
+
+    /// Start recording. Returns nil on success, or a LearningError.
+    public func start(taskDescription: String?) -> LearningError? {
+        os_unfair_lock_lock(&lock)
+        if session != nil { os_unfair_lock_unlock(&lock); return .alreadyRecording }
+        session = LearningSession(taskDescription: taskDescription)
+        lastRecordedAppName = ""
+        os_unfair_lock_unlock(&lock)
+
+        let thread = Thread { [weak self] in self?.runLearningThread() }
+        thread.name = "ghost-learning"
+        thread.qualityOfService = .userInteractive
+        learningThread = thread
+        thread.start()
+
+        // Busy-wait up to 500ms for tap creation
+        for _ in 0..<50 {
+            Thread.sleep(forTimeInterval: 0.01)
+            os_unfair_lock_lock(&lock)
+            let ready = eventTap != nil
+            os_unfair_lock_unlock(&lock)
+            if ready { learningLog("INFO", "Learning: recording started"); return nil }
+        }
+
+        os_unfair_lock_lock(&lock)
+        let failed = eventTap == nil
+        if failed { session = nil }
+        os_unfair_lock_unlock(&lock)
+        return failed ? .inputMonitoringNotGranted : nil
+    }
+
+    /// Stop recording and return the session with its recorded actions.
+    public func stop() -> Result<(LearningSession, [ObservedAction]), LearningError> {
+        os_unfair_lock_lock(&lock)
+        guard var cur = session else { os_unfair_lock_unlock(&lock); return .failure(.notRecording) }
+        flushPendingKeystrokes(into: &cur)
+        flushPendingScroll(into: &cur)
+        let actions = cur.actions
+        let result = cur
+        session = nil
+        os_unfair_lock_unlock(&lock)
+
+        if let rl = learningRunLoop { CFRunLoopStop(rl) }
+        for _ in 0..<200 {
+            if learningThread?.isFinished == true { break }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        learningThread = nil; learningRunLoop = nil
+
+        if actions.isEmpty { return .failure(.noActionsRecorded) }
+        learningLog("INFO", "Learning: stopped, recorded \(actions.count) actions")
+        return .success((result, actions))
+    }
+
+    public func status() -> (isRecording: Bool, actionCount: Int, durationSeconds: Double, currentApp: String?) {
+        os_unfair_lock_lock(&lock); defer { os_unfair_lock_unlock(&lock) }
+        guard let session else { return (false, 0, 0, nil) }
+        let duration = Date().timeIntervalSince(session.startTime)
+        return (true, session.actions.count, duration, lastRecordedAppName.isEmpty ? nil : lastRecordedAppName)
+    }
+
+    // MARK: - Background Thread
+
+    private func runLearningThread() {
+        var mask: CGEventMask = 0
+        for t: CGEventType in [.keyDown, .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp, .scrollWheel] {
+            mask |= (1 << t.rawValue)
+        }
+        let userInfo = Unmanaged.passUnretained(self).toOpaque()
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap, place: .headInsertEventTap, options: .listenOnly,
+            eventsOfInterest: mask, callback: learningEventCallback, userInfo: userInfo
+        ) else {
+            learningLog("ERROR", "Learning: CGEvent tap creation failed (Input Monitoring not granted?)")
+            os_unfair_lock_lock(&lock); session = nil; os_unfair_lock_unlock(&lock)
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(nil, tap, 0)
+        let rl = CFRunLoopGetCurrent()!
+        os_unfair_lock_lock(&lock); eventTap = tap; learningRunLoop = rl; os_unfair_lock_unlock(&lock)
+
+        CFRunLoopAddSource(rl, source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        // Safety timer: auto-stop after max recording duration to prevent runaway recordings
+        let maxFire = CFAbsoluteTimeGetCurrent() + LearningConstants.maxRecordingDurationSeconds
+        let maxTimer = CFRunLoopTimerCreateWithHandler(nil, maxFire, 0, 0, 0) { _ in
+            learningLog("WARN", "Learning: max recording duration reached (\(Int(LearningConstants.maxRecordingDurationSeconds))s), stopping event tap")
+            // Stop the run loop but preserve the session so stop() can harvest the data
+            CFRunLoopStop(CFRunLoopGetCurrent())
+        }
+        CFRunLoopAddTimer(rl, maxTimer, .commonModes)
+        os_unfair_lock_lock(&lock); maxDurationTimer = maxTimer; os_unfair_lock_unlock(&lock)
+
+        learningLog("INFO", "Learning: CGEvent tap started on background thread")
+        CFRunLoopRun()
+
+        // Cleanup
+        CGEvent.tapEnable(tap: tap, enable: false)
+        CFRunLoopRemoveSource(rl, source, .commonModes)
+        os_unfair_lock_lock(&lock)
+        eventTap = nil
+        invalidateTimer(&keystrokeFlushTimer)
+        invalidateTimer(&scrollFlushTimer)
+        invalidateTimer(&maxDurationTimer)
+        os_unfair_lock_unlock(&lock)
+        learningLog("INFO", "Learning: CGEvent tap stopped, thread exiting")
+    }
+
+    private func invalidateTimer(_ timer: inout CFRunLoopTimer?) {
+        if let t = timer { CFRunLoopTimerInvalidate(t); timer = nil }
+    }
+
+    // MARK: - Event Handling (learning thread)
+
+    fileprivate func handleEvent(_ type: CGEventType, _ event: CGEvent) {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            os_unfair_lock_lock(&lock)
+            if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+            os_unfair_lock_unlock(&lock)
+            learningLog("WARN", "Learning: event tap re-enabled after system disabled it")
+            return
+        }
+        os_unfair_lock_lock(&lock)
+        guard session != nil else { os_unfair_lock_unlock(&lock); return }
+        var localLastApp = lastRecordedAppName
+        os_unfair_lock_unlock(&lock)
+
+        AppSwitchDetector.checkAndRecord(recorder: self, lastRecordedApp: &localLastApp)
+
+        os_unfair_lock_lock(&lock)
+        lastRecordedAppName = localLastApp
+        os_unfair_lock_unlock(&lock)
+
+        if let bid = NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+           LearningConstants.restrictedBundleIds.contains(bid) { return }
+
+        switch type {
+        case .keyDown: EventHandlers.handleKeyDown(event, recorder: self)
+        case .leftMouseDown, .rightMouseDown: EventHandlers.handleMouseDown(type, event, recorder: self)
+        case .scrollWheel: EventHandlers.handleScroll(event, recorder: self)
+        default: break
+        }
+    }
+
+    // MARK: - Action Recording
+
+    internal func appendAction(_ action: ObservedAction) {
+        os_unfair_lock_lock(&lock); defer { os_unfair_lock_unlock(&lock) }
+        session?.actions.append(action)
+        if !action.appName.isEmpty { session?.apps.insert(action.appName) }
+        if let url = action.url, !url.isEmpty, !(session?.urls.contains(url) ?? false) {
+            session?.urls.append(url)
+        }
+    }
+
+    // MARK: - Keystroke Coalescing
+
+    /// Flush pending keystrokes into a typeText action. Caller must hold the lock.
+    internal func flushPendingKeystrokes(into session: inout LearningSession) {
+        guard !pendingKeystrokes.isEmpty else { return }
+        session.actions.append(ObservedAction(
+            timestamp: pendingKeystrokeTimestamp,
+            action: .typeText(text: pendingKeystrokes),
+            appName: pendingKeystrokeApp, appBundleId: pendingKeystrokeBundleId,
+            windowTitle: pendingKeystrokeWindow, url: pendingKeystrokeUrl,
+            elementContext: pendingKeystrokeElement
+        ))
+        pendingKeystrokes = ""; pendingKeystrokeElement = nil
+        invalidateTimer(&keystrokeFlushTimer)
+    }
+
+    internal func flushPendingKeystrokesOnLearningThread() {
+        os_unfair_lock_lock(&lock)
+        guard var s = session else { os_unfair_lock_unlock(&lock); return }
+        flushPendingKeystrokes(into: &s); session = s
+        os_unfair_lock_unlock(&lock)
+    }
+
+    internal func scheduleKeystrokeFlushTimer() {
+        os_unfair_lock_lock(&lock)
+        invalidateTimer(&keystrokeFlushTimer)
+        let fire = CFAbsoluteTimeGetCurrent() + LearningConstants.keystrokeFlushTimeoutSeconds
+        let t = CFRunLoopTimerCreateWithHandler(nil, fire, 0, 0, 0) { [weak self] _ in
+            self?.flushPendingKeystrokesOnLearningThread()
+        }
+        keystrokeFlushTimer = t
+        if let rl = learningRunLoop { CFRunLoopAddTimer(rl, t, .commonModes) }
+        os_unfair_lock_unlock(&lock)
+    }
+
+    // MARK: - Scroll Coalescing
+
+    /// Flush pending scroll into a single scroll action. Caller must hold the lock.
+    internal func flushPendingScroll(into session: inout LearningSession) {
+        guard pendingScrollDeltaX != 0 || pendingScrollDeltaY != 0 else { return }
+        session.actions.append(ObservedAction(
+            timestamp: pendingScrollTimestamp,
+            action: .scroll(deltaX: pendingScrollDeltaX, deltaY: pendingScrollDeltaY,
+                           x: pendingScrollX, y: pendingScrollY),
+            appName: pendingScrollApp, appBundleId: pendingScrollBundleId,
+            windowTitle: nil, url: nil, elementContext: nil
+        ))
+        pendingScrollDeltaX = 0; pendingScrollDeltaY = 0
+        invalidateTimer(&scrollFlushTimer)
+    }
+
+    internal func flushPendingScrollOnLearningThread() {
+        os_unfair_lock_lock(&lock)
+        guard var s = session else { os_unfair_lock_unlock(&lock); return }
+        flushPendingScroll(into: &s); session = s
+        os_unfair_lock_unlock(&lock)
+    }
+
+    internal func scheduleScrollFlushTimer() {
+        os_unfair_lock_lock(&lock)
+        invalidateTimer(&scrollFlushTimer)
+        let fire = CFAbsoluteTimeGetCurrent() + LearningConstants.scrollFlushTimeoutSeconds
+        let t = CFRunLoopTimerCreateWithHandler(nil, fire, 0, 0, 0) { [weak self] _ in
+            self?.flushPendingScrollOnLearningThread()
+        }
+        scrollFlushTimer = t
+        if let rl = learningRunLoop { CFRunLoopAddTimer(rl, t, .commonModes) }
+        os_unfair_lock_unlock(&lock)
+    }
+
+    // MARK: - Lock API
+
+    internal func withLock<T>(_ body: (inout LearningSession?) -> T) -> T {
+        os_unfair_lock_lock(&lock); defer { os_unfair_lock_unlock(&lock) }
+        return body(&session)
+    }
+}
+
+// MARK: - C Callback
+
+private nonisolated func learningEventCallback(
+    proxy: CGEventTapProxy, type: CGEventType, event: CGEvent,
+    userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let userInfo else { return Unmanaged.passUnretained(event) }
+    let recorder = Unmanaged<LearningRecorder>.fromOpaque(userInfo).takeUnretainedValue()
+    recorder.handleEvent(type, event)
+    return Unmanaged.passUnretained(event)
+}

--- a/Sources/GhostOS/Learning/LearningTypes.swift
+++ b/Sources/GhostOS/Learning/LearningTypes.swift
@@ -1,0 +1,138 @@
+// LearningTypes.swift - Data types for the self-learning system
+//
+// These types are the OUTPUT of recording. They are NOT recipes.
+// The agent (Claude Code) converts these into Recipe JSON via ghost_recipe_save.
+
+import Foundation
+
+// MARK: - Learning Error
+
+/// Errors specific to learning mode operations.
+public enum LearningError: Error, Sendable {
+    case inputMonitoringNotGranted
+    case alreadyRecording
+    case notRecording
+    case tapCreationFailed
+    case noActionsRecorded
+
+    public var localizedDescription: String {
+        switch self {
+        case .inputMonitoringNotGranted:
+            "Input Monitoring permission not granted"
+        case .alreadyRecording:
+            "Learning is already in progress. Call ghost_learn_stop first."
+        case .notRecording:
+            "No learning session is active. Call ghost_learn_start first."
+        case .tapCreationFailed:
+            "Failed to create CGEvent tap. Input Monitoring permission may be stale."
+        case .noActionsRecorded:
+            "No actions were recorded during the learning session."
+        }
+    }
+
+    public var suggestion: String {
+        switch self {
+        case .inputMonitoringNotGranted:
+            "System Settings > Privacy & Security > Input Monitoring. Add your terminal app. Then restart the MCP server."
+        case .alreadyRecording:
+            "Call ghost_learn_stop to end the current session, or ghost_learn_status to check."
+        case .notRecording:
+            "Call ghost_learn_start to begin recording."
+        case .tapCreationFailed:
+            "Remove and re-add your terminal app in System Settings > Privacy & Security > Input Monitoring."
+        case .noActionsRecorded:
+            "Make sure you performed actions (clicks, typing) while recording was active."
+        }
+    }
+}
+
+// MARK: - Observed Action
+
+/// A single observed user action during learning mode.
+/// Produced by the CGEvent tap + AX enrichment pipeline.
+public struct ObservedAction: Sendable {
+    public let timestamp: UInt64
+    public let action: ObservedActionType
+    public let appName: String
+    public let appBundleId: String
+    public let windowTitle: String?
+    public let url: String?
+    public let elementContext: ElementContext?
+}
+
+/// The type of observed action.
+public enum ObservedActionType: Sendable {
+    case click(x: Double, y: Double, button: String, count: Int)
+    case typeText(text: String)
+    case keyPress(keyCode: Int, keyName: String, modifiers: [String])
+    case hotkey(modifiers: [String], keyName: String)
+    case appSwitch(toApp: String, toBundleId: String)
+    case scroll(deltaX: Int, deltaY: Int, x: Double, y: Double)
+    case secureField
+}
+
+/// AX context for the element that was acted upon (e.g., clicked).
+public struct ElementContext: Sendable {
+    public let role: String?
+    public let title: String?
+    public let identifier: String?
+    public let domId: String?
+    public let domClasses: String?
+    public let computedName: String?
+    public let parentRole: String?
+}
+
+// MARK: - Learning Session
+
+/// State of an active learning session. Held by LearningRecorder.
+public struct LearningSession: Sendable {
+    public let taskDescription: String?
+    public let startTime: Date
+    public var actions: [ObservedAction]
+    public var apps: Set<String>
+    public var urls: [String]
+
+    public nonisolated init(taskDescription: String?) {
+        self.taskDescription = taskDescription
+        self.startTime = Date()
+        self.actions = []
+        self.apps = []
+        self.urls = []
+    }
+}
+
+// MARK: - Learning Log
+
+/// Thread-safe stderr logging for the learning subsystem.
+/// Exists because Log (Logger.swift) inherits MainActor from the package-level
+/// default isolation and cannot be called from the nonisolated learning thread.
+/// Matches Log's output format for consistency in stderr.
+nonisolated func learningLog(_ level: String, _ message: String) {
+    // Per-call allocation is intentional: ISO8601DateFormatter is not thread-safe,
+    // and this function is called from both the main thread and the learning thread.
+    let timestamp = ISO8601DateFormatter().string(from: Date())
+    let line = "[\(timestamp)] [\(level)] \(message)\n"
+    FileHandle.standardError.write(Data(line.utf8))
+}
+
+// MARK: - Learning Constants
+
+nonisolated public enum LearningConstants {
+    /// Keystroke coalescing: flush after this many seconds of inactivity.
+    public static let keystrokeFlushTimeoutSeconds: Double = 0.5
+    /// Scroll coalescing: flush after this many seconds of inactivity.
+    public static let scrollFlushTimeoutSeconds: Double = 0.3
+    /// Maximum recording duration (safety limit): 10 minutes.
+    public static let maxRecordingDurationSeconds: Double = 600
+    /// Restricted bundle IDs: pause recording in these apps.
+    public static let restrictedBundleIds: Set<String> = [
+        "com.apple.keychainaccess",
+        "com.apple.systempreferences",
+        "com.apple.SecurityAgent",
+    ]
+    /// Sensitive field name patterns (case-insensitive).
+    public static let sensitiveFieldPatterns: [String] = [
+        "password", "passwd", "secret", "token", "api_key", "api.key",
+        "apikey", "credential", "private.key", "ssn", "social.security",
+    ]
+}

--- a/Sources/GhostOS/MCP/MCPDispatch.swift
+++ b/Sources/GhostOS/MCP/MCPDispatch.swift
@@ -424,6 +424,16 @@ public enum MCPDispatch {
                 cropBox: cropBox
             )
 
+        // Learning
+        case "ghost_learn_start":
+            return LearningDispatch.learnStart(args: args)
+
+        case "ghost_learn_stop":
+            return LearningDispatch.learnStop(args: args)
+
+        case "ghost_learn_status":
+            return LearningDispatch.learnStatus(args: args)
+
         default:
             return ToolResult(success: false, error: "Unknown tool: \(tool)")
         }

--- a/Sources/GhostOS/MCP/MCPTools.swift
+++ b/Sources/GhostOS/MCP/MCPTools.swift
@@ -1,6 +1,6 @@
 // MCPTools.swift - MCP tool definitions (names, descriptions, parameter schemas)
 //
-// All 20 tools defined here. Agent sees these descriptions and schemas.
+// All 29 tools defined here. Agent sees these descriptions and schemas.
 // Make them excellent - they're the contract between Ghost OS and the agent.
 
 import Foundation
@@ -11,7 +11,7 @@ public enum MCPTools {
     /// All tool definitions as MCP-compatible dictionaries.
     public static func definitions() -> [[String: Any]] {
         var all = perception + actions + wait
-        all += recipes + vision + annotate
+        all += recipes + vision + annotate + learning
         return all
     }
 
@@ -306,6 +306,28 @@ public enum MCPTools {
                 "roles": propArray("string", "AX roles to include (default: buttons, links, fields, checkboxes, combos, tabs, sliders). Example: [\"AXButton\", \"AXLink\"]."),
                 "max_labels": prop("integer", "Maximum number of labels (default: 50, max: 100). Lower values reduce clutter."),
             ]
+        ),
+    ]
+
+    // MARK: - Learning Tools (3)
+
+    private static let learning: [[String: Any]] = [
+        tool(
+            name: "ghost_learn_start",
+            description: "Start observing the user's actions for workflow learning. Ghost OS records clicks, keystrokes, and app switches while the user performs a task manually. Call ghost_learn_stop when the user says they are done. Requires Input Monitoring permission (System Settings > Privacy & Security > Input Monitoring).",
+            properties: [
+                "task_description": prop("string", "Brief description of what the user is about to do (e.g., 'send an email in Gmail'). Helps the synthesis step."),
+            ]
+        ),
+        tool(
+            name: "ghost_learn_stop",
+            description: "Stop observing and return the recorded action sequence. Returns an array of observed actions with AX context (element role, title, DOM id, computed name) for each click and typed text. Use this data to synthesize a recipe via ghost_recipe_save.",
+            properties: [:]
+        ),
+        tool(
+            name: "ghost_learn_status",
+            description: "Check if learning mode is active, how many actions have been recorded, and how long the session has been running.",
+            properties: [:]
         ),
     ]
 

--- a/Sources/ghost/Doctor.swift
+++ b/Sources/ghost/Doctor.swift
@@ -25,6 +25,7 @@ struct Doctor {
         checkBinary()
         checkAccessibility()
         checkScreenRecording()
+        checkInputMonitoring()
         checkProcesses()
         checkMCPConfig()
         checkRecipes()
@@ -68,6 +69,35 @@ struct Doctor {
             print("  [!] Screen Recording: not granted (screenshots won't work)")
             print("    Fix: System Settings > Privacy & Security > Screen Recording")
             print("    Add your terminal app (\(detectHostApp()))")
+            warningCount += 1
+        }
+    }
+
+    // MARK: - Input Monitoring
+
+    private mutating func checkInputMonitoring() {
+        // There is no direct API to check Input Monitoring permission.
+        // The only way is to attempt creating a CGEvent tap.
+        let testMask: CGEventMask = 1 << CGEventType.keyDown.rawValue
+        let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: testMask,
+            callback: { _, _, event, _ in Unmanaged.passUnretained(event) },
+            userInfo: nil
+        )
+
+        if let tap {
+            // Clean up the test tap immediately
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+            print("  [ok] Input Monitoring: granted (for learning mode)")
+        } else {
+            print("  [!] Input Monitoring: not granted (optional, for learning mode)")
+            print("    Fix: System Settings > Privacy & Security > Input Monitoring")
+            print("    Add your terminal app (\(detectHostApp()))")
+            print("    Only needed for ghost_learn (self-learning mode).")
             warningCount += 1
         }
     }

--- a/Sources/ghost/SetupWizard.swift
+++ b/Sources/ghost/SetupWizard.swift
@@ -4,10 +4,11 @@
 //   1. Detect host app (iTerm2, VS Code, Cursor, Terminal)
 //   2. Accessibility permission (opens System Settings to exact pane)
 //   3. Screen Recording permission (optional, for screenshots)
-//   4. MCP configuration for Claude Code (runs claude mcp add)
-//   5. Install bundled recipes
-//   6. Vision setup (Python venv + ShowUI-2B model download)
-//   7. Self-test verification
+//   4. Input Monitoring permission (optional, for learning mode)
+//   5. MCP configuration for Claude Code (runs claude mcp add)
+//   6. Install bundled recipes
+//   7. Vision setup (Python venv + ShowUI-2B model download)
+//   8. Self-test verification
 //
 // Usage: ghost setup
 
@@ -35,16 +36,19 @@ struct SetupWizard {
         // Step 3: Screen Recording (optional)
         let hasScreenRecording = checkScreenRecording(hostApp: hostApp)
 
-        // Step 4: MCP configuration
+        // Step 4: Input Monitoring (optional)
+        checkInputMonitoring(hostApp: hostApp)
+
+        // Step 5: MCP configuration
         configureMCP()
 
-        // Step 5: Install recipes
+        // Step 6: Install recipes
         installRecipes()
 
-        // Step 6: Vision setup (venv + model)
+        // Step 7: Vision setup (venv + model)
         let hasVision = setupVision()
 
-        // Step 7: Self-test
+        // Step 8: Self-test
         let verified = selfTest(
             hasAccess: hasAccess,
             hasScreenRecording: hasScreenRecording,
@@ -183,10 +187,54 @@ struct SetupWizard {
         return false
     }
 
-    // MARK: - Step 4: MCP Configuration
+    // MARK: - Step 4: Input Monitoring Permission (optional)
+
+    private func checkInputMonitoring(hostApp: String) {
+        printStep(4, "Input Monitoring Permission (optional)")
+
+        // Test by attempting tap creation
+        let testMask: CGEventMask = 1 << CGEventType.keyDown.rawValue
+        let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: testMask,
+            callback: { _, _, event, _ in Unmanaged.passUnretained(event) },
+            userInfo: nil
+        )
+
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+            printOK("Granted")
+            return
+        }
+
+        print("  Self-learning mode lets Ghost OS watch you perform tasks")
+        print("  and turn them into reusable recipes.")
+        print("  \(hostApp) needs Input Monitoring permission for this.")
+        print("")
+        print("  Set it up now? (y/N) ", terminator: "")
+        fflush(stdout)
+
+        guard let answer = readLine()?.lowercased(), answer == "y" || answer == "yes" else {
+            printOK("Skipped (you can set this up later)")
+            return
+        }
+
+        openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")
+        print("")
+        print("  Add \"\(hostApp)\" to the Input Monitoring list.")
+        print("  Press Enter after granting...")
+        _ = readLine()
+
+        printOK("Permission change may require restarting the terminal app.")
+    }
+
+    // MARK: - Step 5: MCP Configuration
 
     private func configureMCP() {
-        printStep(4, "MCP Configuration")
+        printStep(5, "MCP Configuration")
 
         let binaryPath = resolveBinaryPath()
 
@@ -282,10 +330,10 @@ struct SetupWizard {
         printOK("Configured")
     }
 
-    // MARK: - Step 5: Install Recipes
+    // MARK: - Step 6: Install Recipes
 
     private func installRecipes() {
-        printStep(5, "Bundled Recipes")
+        printStep(6, "Bundled Recipes")
 
         let recipesDir = NSHomeDirectory() + "/.ghost-os/recipes"
         try? FileManager.default.createDirectory(atPath: recipesDir, withIntermediateDirectories: true)
@@ -322,10 +370,10 @@ struct SetupWizard {
         printOK("\(total) recipe(s) available")
     }
 
-    // MARK: - Step 6: Vision Setup
+    // MARK: - Step 7: Vision Setup
 
     private func setupVision() -> Bool {
-        printStep(6, "Vision (ShowUI-2B)")
+        printStep(7, "Vision (ShowUI-2B)")
 
         // Check if ghost-vision is available
         let hasLauncher = findGhostVisionBinary() != nil
@@ -707,10 +755,10 @@ struct SetupWizard {
         return nil
     }
 
-    // MARK: - Step 7: Self-Test
+    // MARK: - Step 8: Self-Test
 
     private func selfTest(hasAccess: Bool, hasScreenRecording: Bool, hasVision: Bool) -> Bool {
-        printStep(7, "Self-Test")
+        printStep(8, "Self-Test")
 
         guard hasAccess else {
             printFail("Skipped (needs Accessibility permission)")


### PR DESCRIPTION
## Summary

Ghost OS can now **watch you work and learn from it**. Three new MCP tools let Claude observe a user's manual actions, then synthesize them into a replayable recipe.

- `ghost_learn_start` -- begin recording user actions via CGEvent tap + AX enrichment
- `ghost_learn_stop` -- stop recording, return enriched action sequence with full AX context
- `ghost_learn_status` -- check recording state, action count, duration

**How it works:** User says "watch me send an email" -> Claude calls `ghost_learn_start` -> user performs the task manually -> Claude calls `ghost_learn_stop` -> Ghost OS returns every click, keystroke, and app switch with AX element context (role, title, DOM id, computed name) -> Claude synthesizes a parameterized Recipe JSON -> saves it via `ghost_recipe_save`. Ghost OS stays LLM-free.

### New files (Sources/GhostOS/Learning/)
| File | Lines | Purpose |
|------|-------|---------|
| LearningTypes.swift | 138 | ObservedAction, ElementContext, LearningSession, LearningError |
| LearningRecorder.swift | 305 | CGEvent tap lifecycle, background thread, os_unfair_lock buffer |
| EventHandlers.swift | 256 | Key/mouse/scroll handling, AX enrichment, 3-tier secure field detection |
| AppSwitchDetector.swift | 55 | Frontmost app polling for Cmd+Tab / gesture detection |
| LearningDispatch.swift | 129 | MCP tool handlers, JSON serialization |

### Modified files
- **MCPTools.swift** -- 3 new tool definitions (29 total, was 26)
- **MCPDispatch.swift** -- 3 new dispatch cases
- **Doctor.swift** -- Input Monitoring permission check (optional, warning only)
- **SetupWizard.swift** -- Optional Input Monitoring setup step (y/N)
- **GHOST-MCP.md** -- Rule 13: Self-Learning Mode + tool reference updates
- **README.md** -- What's New v2.2.0 section
- **Types.swift** -- Version bump to 2.2.0

### Thread safety
- CGEvent tap on dedicated `Thread("ghost-learning")` with own CFRunLoop
- `os_unfair_lock` on all shared mutable state
- Lock-protected local copy pattern for cross-thread app name tracking
- Max duration safety timer (600s) stops event tap, preserves session data
- No async/await, no actors, no DispatchQueue

### Privacy
- 3-tier secure field detection (AXSecureTextField role, subrole, name patterns)
- 11 sensitive field name patterns (password, secret, token, api_key, ssn, ...)
- Restricted bundle IDs silently skipped (Keychain Access, System Preferences, SecurityAgent)
- All data ephemeral (in-memory only, never written to disk)

### Testing
- 16/16 automated E2E tests pass (MCP protocol over stdio)
- Live test: 20 actions captured in 44 seconds (clicks, typing, right-click, double-click, menu items, keystroke coalescing -- all with AX context)
- 2 adversarial code reviews (Opus 4.6, ultrathink): all P0/P1 issues found and fixed

## Test plan
- [x] `swift build` passes with zero warnings
- [x] 29 tools registered (was 26)
- [x] ghost_learn_start succeeds with Input Monitoring permission
- [x] ghost_learn_start returns error without permission (actionable message)
- [x] Double start returns `.alreadyRecording` error
- [x] ghost_learn_stop without start returns `.notRecording` error
- [x] ghost_learn_status shows recording=true/false correctly
- [x] Live recording captures clicks, typing, hotkeys, right-clicks, double-clicks
- [x] AX enrichment provides role, title, identifier, DOM id, computed name
- [x] Keystroke coalescing groups characters with 500ms timeout
- [x] Null fields serialize as JSON `null` (not omitted)
- [x] Existing 26 tools unaffected (regression test)
- [x] ghost doctor reports Input Monitoring status correctly
- [x] Version reports 2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)